### PR TITLE
Update lap_score.py

### DIFF
--- a/skfeature/function/similarity_based/lap_score.py
+++ b/skfeature/function/similarity_based/lap_score.py
@@ -31,9 +31,11 @@ def lap_score(X, **kwargs):
 
     # if 'W' is not specified, use the default W
     if 'W' not in kwargs.keys():
+        # construct the affinity matrix W
         W = construct_W(X)
-    # construct the affinity matrix W
-    W = kwargs['W']
+    else:
+        # Use specified affinity matrix W.
+        W = kwargs['W']
     # build the diagonal D matrix from affinity matrix W
     D = np.array(W.sum(axis=1))
     L = W


### PR DESCRIPTION
Fix the Kwargs key error bug which will arise when affinity matrix W is not specified.